### PR TITLE
Upgrade `rubyzip` gem to avoid security vulnerabilities

### DIFF
--- a/lt-lcms.gemspec
+++ b/lt-lcms.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
   spec.add_dependency 'google-api-client'
   spec.add_dependency 'httparty'
   spec.add_dependency 'lt-google-api', '~> 0.1'
-  spec.add_dependency 'rubyzip', '~> 1.2.2'
+  spec.add_dependency 'rubyzip', '>= 1.3.0'
 
   spec.add_development_dependency 'bundler', '~> 1.16'
   spec.add_development_dependency 'bundler-audit'


### PR DESCRIPTION
The [vulnerabality](https://github.com/learningtapestry/lcms-engine/network/alert/lcms-engine.gemspec/rubyzip/closed)